### PR TITLE
Solving #17 add multiple bash checks

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,16 +9,25 @@ on:
     branches: [ master ]
 
 jobs:
-  linux-test:
-    name: Linux Test
+  test:
+    name: ShellCheck
     runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@master
     - name: Run ShellCheck
       uses: ludeeus/action-shellcheck@0.5.0
-    - name: Syntax Testing
-      # -n : ead  commands  but  do  not  execute  them.  This may be used to check a shell script for syntax errors.  This is ignored by interactive shells.
-      run : |
-          bash -n dotman.sh
-          sh -n tools/install.sh          
-    
+  bash:
+    name: BashTesting
+    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        bash: ["3.0", "4.0", "5.0"]
+        cmd: ["bash -n dotman.sh", "sh -n tools/install.sh"]
+    steps:          
+    - uses: actions/checkout@master
+    - name: "Test ${{ matrix.cmd }} with bash ${{ matrix.bash }}"
+      uses: addnab/docker-run-action@v3
+      with:
+        image: bash:${{ matrix.bash }}
+        options: -v ${{ github.workspace }}:/test -w /test
+        run: ${{ matrix.cmd }}


### PR DESCRIPTION
Hey,

I added the possibility to check the executable with different bash versions (#17).  I also split them up in separate jobs, for an accurate catching of the exit codes.

Best regards,
fi-do