### PR TITLE
Solve issue #17 - test multiple bash versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,7 @@ name: build
 # events but only for the master branch
 on:
   push:
-    branches: [ master, feature/* ]
+    branches: [ master ]
   pull_request:
     branches: [ master ]
 jobs:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,11 +33,15 @@ jobs:
         ]
     steps:
       - uses: actions/checkout@master
-      - name: matrix test ${{ matrix.bash }}
+      - name: test tools/install.sh with bash ${{ matrix.bash }}
         uses: addnab/docker-run-action@v3
         with:
           image: bash:${{ matrix.bash }}
           options: -v ${{ github.workspace }}:/work -w /work
-          run: |
-            bash -n dotman.sh
-            sh -n tools/install.sh          
+          run: sh -n tools/install.sh          
+      - name: test dotman.sh with bash ${{ matrix.bash }}
+        uses: addnab/docker-run-action@v3
+        with:
+          image: bash:${{ matrix.bash }}
+          options: -v ${{ github.workspace }}:/work -w /work
+          run: bash -n dotman.sh

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,14 +4,14 @@ name: build
 # events but only for the master branch
 on:
   push:
-    branches: [ master ]
+    branches: [ master, feature/* ]
   pull_request:
     branches: [ master ]
 
 jobs:
-  linux-test:
+  shellcheck:
     name: Linux Test
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@master
     - name: Run ShellCheck
@@ -21,4 +21,25 @@ jobs:
       run : |
           bash -n dotman.sh
           sh -n tools/install.sh          
-    
+  bash:
+    name: bash-matrix
+    runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        bash: [ 
+          "3.0",
+          "3.1", 
+          "4.4", 
+          "5.1",
+          "5.2"
+        ]
+    steps:
+      - uses: actions/checkout@master
+      - name: matrix test ${{ matrix.bash }}
+        uses: addnab/docker-run-action@v3
+        with:
+          node-version: bash:${{ matrix.bash }}
+          options: -v ${{ github.workspace }}:/test -w /test
+          run: |
+            bash -n dotman.sh
+            sh -n tools/install.sh          

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,8 +19,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        bash: [ 
-          "3.0",
+        bash: [
           "3.1",
           "3.2",
           "4.0",

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,8 +38,8 @@ jobs:
       - name: matrix test ${{ matrix.bash }}
         uses: addnab/docker-run-action@v3
         with:
-          node-version: bash:${{ matrix.bash }}
-          options: -v ${{ github.workspace }}:/test -w /test
+          image: bash:${{ matrix.bash }}
+          options: -v ${{ github.workspace }}:/work -w /work
           run: |
             bash -n dotman.sh
             sh -n tools/install.sh          

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,4 @@
 name: build
-
 # Controls when the action will run. Triggers the workflow on push or pull request
 # events but only for the master branch
 on:
@@ -7,20 +6,14 @@ on:
     branches: [ master, feature/* ]
   pull_request:
     branches: [ master ]
-
 jobs:
   shellcheck:
-    name: Linux Test
+    name: shellcheck
     runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@master
     - name: Run ShellCheck
-      uses: ludeeus/action-shellcheck@0.5.0
-    - name: Syntax Testing
-      # -n : ead  commands  but  do  not  execute  them.  This may be used to check a shell script for syntax errors.  This is ignored by interactive shells.
-      run : |
-          bash -n dotman.sh
-          sh -n tools/install.sh          
+      uses: ludeeus/action-shellcheck@2.0.0        
   bash:
     name: bash-matrix
     runs-on: ubuntu-22.04
@@ -28,8 +21,13 @@ jobs:
       matrix:
         bash: [ 
           "3.0",
-          "3.1", 
-          "4.4", 
+          "3.1",
+          "3.2",
+          "4.0",
+          "4.1",
+          "4.2",
+          "4.3",
+          "4.4",
           "5.1",
           "5.2"
         ]


### PR DESCRIPTION
Fixes issue #17 

- Updated ubuntu to version 22.04
- Removed the solo test and renamed from LInux test to shellcheck
- Added tests for bash 3.1 up to bash 5.2
- bash 3.0 test fails so I didn't include this, but it's trivial to add if you want to fix the (minor) error